### PR TITLE
Spring Season 2026 Update

### DIFF
--- a/counterstrike2.md
+++ b/counterstrike2.md
@@ -54,7 +54,7 @@ Competition formats, including group stages, playoffs, and qualifiers, are annou
 
 Standard formats may include round-robin groups, elimination brackets, or mixed formats.
 
-For regular season reschedules, teams must announce their intent to reschedule to tournament administration at least 48 hours before the new match time. After both teams confirm the new date and time, the match must also comply with the General Rulebook rescheduling notice deadline.
+For regular season reschedules, teams must announce their intent to reschedule to league administration. After both teams mutually agree on a new date and time, the rescheduled match must be announced at least 48 hours before the new match time and must also comply with the General Rulebook rescheduling notice deadline.
 
 ---
 

--- a/counterstrike2.md
+++ b/counterstrike2.md
@@ -40,7 +40,11 @@ Changes made to a team's roster do not automatically apply to the running compet
 Roster management differs between tournaments/qualifiers and league series:
 
 - **Tournaments and Qualifiers:** Rosters are locked at the start and no roster changes are permitted during competition, except emergency substitutions approved by admins.
-- **League Series:** Roster changes are governed by the **Substitution Token** system in the General Rulebook (Section 2.4.4).
+- **League Series:** Roster changes are governed by the **Substitution Token** system in the General Rulebook (Section 2.4.4), with the following CS2-specific provisions:
+  - Teams receive **2 Substitution Tokens** for the regular season.
+  - At the start of playoffs/relegation-promotion, each team receives a **full refill to 2 Substitution Tokens**.
+  - After the regular season ends, no foreign players may be newly added to a league roster.
+  - Horizontal and upward transfers between league teams are permitted only once per player per season, and only if the player has played fewer than 3 official league matches for the source team in that season.
 
 ---
 

--- a/counterstrike2.md
+++ b/counterstrike2.md
@@ -44,7 +44,7 @@ Roster management differs between tournaments/qualifiers and league series:
   - Teams receive **2 Substitution Tokens** for the regular season.
   - At the start of playoffs/relegation-promotion, each team receives a **full refill to 2 Substitution Tokens**.
   - After the regular season ends, no foreign players may be newly added to a league roster.
-  - Horizontal and upward transfers between league teams are permitted only once per player per season, and only if the player has played fewer than 3 official league matches for the source team in that season.
+  - Horizontal and upward transfers between league teams are permitted only once per player per season, and only if the player has not yet played in 3 official league matches for the source team in that season.
 
 ---
 

--- a/counterstrike2.md
+++ b/counterstrike2.md
@@ -44,8 +44,7 @@ Roster management differs between tournaments/qualifiers and league series:
   - Teams receive **2 Substitution Tokens** for the regular season.
   - At the start of playoffs/relegation-promotion, each team receives a **full refill to 2 Substitution Tokens**.
   - After the regular season ends, no foreign players may be newly added to a league roster.
-  - Horizontal and upward transfers between league teams are permitted only once per player per season, and only if the player has not yet played in 3 official league matches for the source team in that season.
-
+  - Transfers between league teams at the same tier/division (horizontal) or to higher tiers/divisions (upward) are permitted only once per player per season, and only if the player has played in fewer than 3 official league matches for the source team in that season.
 ---
 
 ## 3. CS2 Competition Format
@@ -54,7 +53,7 @@ Competition formats, including group stages, playoffs, and qualifiers, are annou
 
 Standard formats may include round-robin groups, elimination brackets, or mixed formats.
 
-For regular season reschedules, teams must announce their intent to reschedule to league administration. After both teams mutually agree on a new date and time, the rescheduled match must be announced at least 48 hours before the new match time and must also comply with the General Rulebook rescheduling notice deadline.
+For regular season reschedules, teams must announce their intent to reschedule to league administration. After both teams mutually agree on a new date and time, the rescheduled match must be announced at least 48 hours before the new match time to the league administration and must also comply with the General Rulebook rescheduling notice deadline.
 
 ---
 

--- a/counterstrike2.md
+++ b/counterstrike2.md
@@ -35,7 +35,7 @@ For general eligibility, conduct, media, data, prizes, and legal terms, refer to
 
 - Teams must declare all substitutes before competition start.
 - **Emergency substitutions** require prior admin approval in accordance with the General Rulebook (Section 2.4.2).
-Changes made to a team's roster do not automatically apply to the running competition; changes are only effective once announced to admins and listed on the official competition page.
+- Changes made to a team's roster do not automatically apply to the running competition; changes are only effective once announced to admins and listed on the official competition page.
 
 Roster management differs between tournaments/qualifiers and league series:
 
@@ -53,7 +53,7 @@ Competition formats, including group stages, playoffs, and qualifiers, are annou
 
 Standard formats may include round-robin groups, elimination brackets, or mixed formats.
 
-For regular season reschedules, teams must announce their intent to reschedule to league administration. After both teams mutually agree on a new date and time, the rescheduled match must be announced at least 48 hours before the new match time to the league administration and must also comply with the General Rulebook rescheduling notice deadline.
+For regular season reschedules, teams must announce their intent to reschedule to league administration. After both teams mutually agree on a new date and time, the rescheduled match must be announced to league administration at least 48 hours before the new match time.
 
 ---
 

--- a/counterstrike2.md
+++ b/counterstrike2.md
@@ -31,15 +31,16 @@ For general eligibility, conduct, media, data, prizes, and legal terms, refer to
 - All players must register their **primary Steam accounts** before the tournament.  
 - **Account sharing, smurfing, or multi-teaming is strictly prohibited.**
 
-### 2.3. Substitutions
+### 2.3. Substitutions and Roster Management
 
-#### Pre-Tournament:
-- Substitutes must be declared before the tournament starts.  
-- Emergency substitutes require **admin approval** and are only permitted in serious cases (e.g., health issues, technical failure).
+- Teams must declare all substitutes before competition start.
+- **Emergency substitutions** require prior admin approval in accordance with the General Rulebook (Section 2.4.2).
+Changes made to a team's roster do not automatically apply to the running competition; changes are only effective once announced to admins and listed on the official competition page.
 
-#### In-Tournament:
-- Substitutions between maps are allowed within the roster limits.  
-- **Last-minute substitutions** are only permitted if both the **opponent and admins agree**.
+Roster management differs between tournaments/qualifiers and league series:
+
+- **Tournaments and Qualifiers:** Rosters are locked at the start and no roster changes are permitted during competition, except emergency substitutions approved by admins.
+- **League Series:** Roster changes are governed by the **Substitution Token** system in the General Rulebook (Section 2.4.4).
 
 ---
 

--- a/counterstrike2.md
+++ b/counterstrike2.md
@@ -54,6 +54,8 @@ Competition formats, including group stages, playoffs, and qualifiers, are annou
 
 Standard formats may include round-robin groups, elimination brackets, or mixed formats.
 
+For regular season reschedules, teams must announce their intent to reschedule to tournament administration at least 48 hours before the new match time. After both teams confirm the new date and time, the match must also comply with the General Rulebook rescheduling notice deadline.
+
 ---
 
 ## 4. Game Setup & Match Rules

--- a/general.md
+++ b/general.md
@@ -347,7 +347,7 @@ In Regular Seasons of Leagues, matches may be rescheduled if both teams mutually
 
 #### 4.4.2. Rescheduling Process
 
-All rescheduled matches must be announced to the competition administration at least 48 hours before the new match time.
+All rescheduled matches must be announced to the competition administration at least 24 hours before the new match time.
 
 #### 4.4.3. Rescheduling Limitations
 

--- a/general.md
+++ b/general.md
@@ -192,14 +192,13 @@ In exceptional scenarios, tournament administration may approve case-by-case per
 - Regulatory or legal compliance requirements
 - Comparable force-majeure or administrative events of similar severity
 
-This clause is distinct from Section 2.4.2 emergency substitutions: emergency substitutions remain the primary and first-line mechanism for temporary short-term replacement. Permanent exceptional roster approvals under this clause may be granted only after Section 2.4.2 options are exhausted or demonstrably insufficient, and only with documented approval by the Head Admin or delegated board authority.
+This permanent exception mechanism is distinct from the temporary emergency substitution provisions above: emergency substitutions remain the primary and first-line mechanism for short-term replacement. Permanent exceptional roster approvals under this clause may be granted only after temporary emergency substitution options are exhausted or demonstrably insufficient, and only with documented approval by the Head Admin or delegated board authority.
 
 All approvals under this clause must:
 - Be documented in writing with factual grounds, scope, and duration
-- Be disclosed to all competing teams within 24 hours
-- Be sent directly to all materially affected teams without delay
-
-Any team directly affected by such approval may file an appeal under Section 8 (Appeals Process), including the filing timelines and procedure set out in Section 8.4. Exceptional approvals are case-specific and do not create automatic precedent.
+- Be disclosed to all competing teams within 24 hours of the approval
+- Be sent directly to materially affected teams immediately (and in all cases within the 24-hour disclosure period)
+Any team directly affected by such approval may file an appeal under Section 8 (Appeals Process). Exceptional roster approvals under this clause are appealable decisions under Section 8.2 and are subject to the filing timelines and procedure set out in Section 8.4. Exceptional approvals are case-specific and do not create automatic precedent.
 
 #### 2.4.3. Roster Locks, Transfer Windows, and Token System
 
@@ -358,9 +357,7 @@ In Regular Seasons of Leagues, matches may be rescheduled if both teams mutually
 - Matches generally must be played no later than the officially scheduled date and time
 - Matches cannot be played before the start of the competition week (Monday 00:00 Swiss Time)
 - Matches of the first week may be scheduled in the week after, but not before the official start of the season
-
-Matches which are planned to be streamed by the Ibex Gaming League are generally not allowed to be rescheduled.
-
+Matches planned to be streamed by the Ibex Gaming League may not be rescheduled, except under the emergency rescheduling provisions in Section 4.4.4.
 #### 4.4.2. Rescheduling Process
 
 All rescheduled matches must be announced to the competition administration at least 24 hours before the new match time.
@@ -620,6 +617,7 @@ The following decisions may be appealed:
 - Prize forfeiture decisions
 - Sanctions based on disputed factual findings
 - Procedural violations in the investigation process
+- Exceptional roster approvals under Section 2.4.2
 
 ### 8.3. Non-Appealable Decisions
 

--- a/general.md
+++ b/general.md
@@ -174,7 +174,7 @@ Teams may represent organisations subject to the following restrictions:
 #### 2.4.1. Initial Roster Submission
 
 Teams must submit complete rosters before competition commencement, including all substitutes as defined by game-specific rules.
-Roster changes during competition are governed by Section 2.4.3 (tournaments/qualifiers roster lock and league series token system).
+Roster changes during competition are governed by the applicable provisions of Sections 2.4.2, 2.4.3, and 2.4.5, including emergency substitutions and exceptional permanent roster approvals, tournaments/qualifiers roster locks, the league series token system, and any permitted roster changes outside tokens.
 Changes to a team's roster on our platform do **not** automatically apply to an ongoing competition. Any roster change must be announced to tournament administration and is only effective once it is officially listed on the relevant **competition page**.
 Roster change announcements must include each affected player's ID. The player's account must contain all required sign-up information for the competition (as required at initial registration); if such information is missing from the account, it must be included in the roster change report.
 #### 2.4.2. Emergency Substitutions

--- a/general.md
+++ b/general.md
@@ -210,7 +210,7 @@ Where qualification from a qualifier or prior phase grants entry into a subseque
 
 #### 2.4.4. Substitution Tokens (League Series Only)
 
-**Purpose:** Substitution Tokens allow teams to **add a new player** to the active roster during a league season. Each token can be used either to permanently add a player for the remainder of the season or to temporarily add a player for a single match. Removing a player from the active roster is free and does not require a token.
+**Purpose:** Substitution Tokens allow teams to **add a new player** to the active roster during a league season. Each token can be used either to permanently add a player for the remainder of the season. Removing a player from the active roster is free and does not require a token.
 
 **Allocation:**
 - **Regular Season:** Each team receives **2 Substitution Tokens**

--- a/general.md
+++ b/general.md
@@ -174,7 +174,9 @@ Teams may represent organisations subject to the following restrictions:
 #### 2.4.1. Initial Roster Submission
 
 Teams must submit complete rosters before competition commencement, including all substitutes as defined by game-specific rules.
-Roster changes during the competition may be allowed in accordance with competition-specific rules.
+Roster changes during competition are governed by Section 2.4.3 (tournaments/qualifiers roster lock and league series token system).
+Changes to a team's roster on our platform do **not** automatically apply to an ongoing competition. Any roster change must be announced to tournament administration and is only effective once it is officially listed on the relevant **competition page**.
+Roster change announcements must include each affected player's ID. The player's account must contain all required sign-up information for the competition (as required at initial registration); if such information is missing from the account, it must be included in the roster change report.
 #### 2.4.2. Emergency Substitutions
 
 Emergency substitutions require **advance approval from tournament administration** and are permitted only for:
@@ -183,9 +185,43 @@ Emergency substitutions require **advance approval from tournament administratio
 - Unforeseen travel or technical difficulties
 - Other circumstances deemed acceptable by the administration
 
-#### 2.4.3. Roster Locks and Transfer Windows
+#### 2.4.3. Roster Locks, Transfer Windows, and Token System
 
-Competitions may establish **roster lock dates** and **transfer windows** as specified in competition-specific regulations. For teams advancing between competition phases, **only a minority of the active roster may be changed** after qualification, with specific thresholds defined per game.
+**Tournaments and Qualifiers:** Rosters are **locked at the start of the competition** and **no roster changes are permitted during the tournament or qualifier**, except for emergency substitutions with administrator approval (see Section 2.4.2). Teams must finalize their roster before the competition commences.
+
+**League Series:** League play (regular season, playoffs, and final matches) is governed by a **Substitution Token** system described below. Teams advancing to a league phase must adhere to the roster lock deadline, defined as **the last scheduled qualifier date for that season, or the date communicated by tournament administration** if no qualifiers exist.
+
+#### 2.4.4. Substitution Tokens (League Series Only)
+
+**Purpose:** Substitution Tokens allow teams to **add a new player** to the active roster during a league season. Each token can be used either to permanently add a player for the remainder of the season or to temporarily add a player for a single match. Removing a player from the active roster is free and does not require a token.
+
+**Allocation:**
+- **Regular Season:** Each team receives **2 Substitution Tokens**
+- **Playoffs and Final Matches:** Allocation is reduced to a **maximum of 1 token**
+  - Teams that used 1 token in regular season retain 1 for playoffs
+  - Teams that used 2 tokens have no tokens remaining for playoffs
+  - Teams that used 0 tokens enter playoffs with 1 token available
+
+**Usage - Permanent Addition:**
+- **Adding a permanent player** to the active roster costs **1 Substitution Token**
+- The new player joins the active roster for the remainder of the league series (regular season, playoffs, or final matches)
+- Removed or previous players remain on the registered roster and may return via another Substitution Token
+- Once a token is used for permanent addition, it cannot be recovered
+
+**Usage - Temporary Addition:**
+- **Adding a temporary player** for a single match costs **1 Substitution Token**
+- The temporary player plays only that match and does not count toward the normal roster size limit
+- After the match, the roster returns to normal.
+
+**General Usage Rules:**
+- **Removing a player from the active roster is always free** and does not require a token
+- Tokens may be used at any point during their applicable phase (regular season, playoffs, or final/relegation matches)
+- Once a token is used, it cannot be recovered
+- Specific roster size limits are defined in game-specific rulebooks
+
+#### 2.4.5. Emergency Substitutions (Outside Token System)
+
+Emergency substitutions (medical emergencies, technical failures, etc.) are **free and outside the Substitution Token system**. They require **advance approval from tournament administration** and do not consume any tokens (see Section 2.4.2).
 
 ---
 

--- a/general.md
+++ b/general.md
@@ -225,11 +225,6 @@ Where qualification from a qualifier or prior phase grants entry into a subseque
 - Removed or previous players remain on the registered roster and may return via another Substitution Token
 - Once a token is used for permanent addition, it cannot be recovered
 
-**Usage - Temporary Addition:**
-- **Adding a temporary player** for a single match costs **1 Substitution Token**
-- The temporary player plays only that match and does not count toward the normal roster size limit
-- After the match, the roster returns to normal.
-
 **General Usage Rules:**
 - **Removing a player from the active roster is always free** and does not require a token
 - Tokens may be used at any point during their applicable phase (regular season, playoffs, or final/relegation matches)

--- a/general.md
+++ b/general.md
@@ -352,7 +352,7 @@ In Regular Seasons of Leagues, matches may be rescheduled if both teams mutually
 - Matches generally must be played no later than the officially scheduled date and time
 - Matches cannot be played before the start of the competition week (Monday 00:00 Swiss Time)
 - Matches of the first week may be scheduled in the week after, but not before the official start of the season
-Matches planned to be streamed by the Ibex Gaming League may not be rescheduled, except under the emergency rescheduling provisions in Section 4.4.4.
+- Matches planned to be streamed by the Ibex Gaming League may not be rescheduled, except under the emergency rescheduling provisions in Section 4.4.4.
 #### 4.4.2. Rescheduling Process
 
 All rescheduled matches must be announced to the competition administration at least 24 hours before the new match time.

--- a/general.md
+++ b/general.md
@@ -612,7 +612,7 @@ The following decisions may be appealed:
 - Prize forfeiture decisions
 - Sanctions based on disputed factual findings
 - Procedural violations in the investigation process
-- Exceptional roster approvals under Section 2.4.2
+- Exceptional roster approval decisions under the exceptional-approval provisions of Section 2.4.2 (excluding emergency substitution decisions)
 
 ### 8.3. Non-Appealable Decisions
 

--- a/general.md
+++ b/general.md
@@ -185,7 +185,21 @@ Emergency substitutions require **advance approval from tournament administratio
 - Unforeseen travel or technical difficulties
 - Other circumstances deemed acceptable by the administration
 
-In exceptional scenarios, tournament administration may approve roster changes outside standard roster restrictions where necessary to protect competitive integrity, fairness, or operational continuity. Such approvals are case-specific, must be documented, and do not create an automatic precedent for future cases.
+In exceptional scenarios, tournament administration may approve case-by-case permanent roster exceptions outside standard roster restrictions only where strict compliance would be impossible or materially unfair due to circumstances such as:
+- Team dissolution or organisational collapse
+- Serious medical emergency with longer-term player unavailability
+- Venue access or travel access failure outside team control
+- Regulatory or legal compliance requirements
+- Comparable force-majeure or administrative events of similar severity
+
+This clause is distinct from Section 2.4.2 emergency substitutions: emergency substitutions remain the primary and first-line mechanism for temporary short-term replacement. Permanent exceptional roster approvals under this clause may be granted only after Section 2.4.2 options are exhausted or demonstrably insufficient, and only with documented approval by the Head Admin or delegated board authority.
+
+All approvals under this clause must:
+- Be documented in writing with factual grounds, scope, and duration
+- Be disclosed to all competing teams within 24 hours
+- Be sent directly to all materially affected teams without delay
+
+Any team directly affected by such approval may file an appeal under Section 8 (Appeals Process), including the filing timelines and procedure set out in Section 8.4. Exceptional approvals are case-specific and do not create automatic precedent.
 
 #### 2.4.3. Roster Locks, Transfer Windows, and Token System
 
@@ -193,7 +207,7 @@ In exceptional scenarios, tournament administration may approve roster changes o
 
 **League Series:** League play (regular season, playoffs, and final matches) is governed by a **Substitution Token** system described below, unless a game-specific rulebook defines an alternative league roster mechanism. Teams advancing to a league phase must adhere to the roster lock deadline, defined as **the last scheduled qualifier date for that season, or the date communicated by tournament administration** if no qualifiers exist.
 
-Where qualification from a qualifier or prior phase grants entry into a subsequent competition phase, the team must retain a majority of players from its qualifying roster, unless a game-specific or competition-specific rule imposes a stricter requirement, or tournament administration grants an exceptional approval under Section 2.4.2.
+Where qualification from a qualifier or prior phase grants entry into a subsequent competition phase, the team must retain a majority of players from its qualifying roster, unless a game-specific or competition-specific rule imposes a stricter requirement, or tournament administration grants an exceptional approval under this clause.
 
 #### 2.4.4. Substitution Tokens (League Series Only)
 
@@ -345,6 +359,8 @@ In Regular Seasons of Leagues, matches may be rescheduled if both teams mutually
 - Matches cannot be played before the start of the competition week (Monday 00:00 Swiss Time)
 - Matches of the first week may be scheduled in the week after, but not before the official start of the season
 
+Matches which are planned to be streamed by the Ibex Gaming League are generally not allowed to be rescheduled.
+
 #### 4.4.2. Rescheduling Process
 
 All rescheduled matches must be announced to the competition administration at least 24 hours before the new match time.
@@ -358,7 +374,6 @@ If teams cannot reach an agreement on rescheduling, the match must be played on 
 In emergency situations (technical issues, medical emergencies, etc.), teams may request last-minute rescheduling by contacting the administration immediately.
 
 Administration reserves the right to deny unreasonable rescheduling requests or those that may compromise the competitive integrity of the tournament. 
-Matches which are planned to be streamed by the Ibex Gaming League are generally not allowed to be rescheduled.
 
 ---
 

--- a/general.md
+++ b/general.md
@@ -185,11 +185,15 @@ Emergency substitutions require **advance approval from tournament administratio
 - Unforeseen travel or technical difficulties
 - Other circumstances deemed acceptable by the administration
 
+In exceptional scenarios, tournament administration may approve roster changes outside standard roster restrictions where necessary to protect competitive integrity, fairness, or operational continuity. Such approvals are case-specific, must be documented, and do not create an automatic precedent for future cases.
+
 #### 2.4.3. Roster Locks, Transfer Windows, and Token System
 
 **Tournaments and Qualifiers:** Rosters are **locked at the start of the competition** and **no roster changes are permitted during the tournament or qualifier**, except for emergency substitutions with administrator approval (see Section 2.4.2). Teams must finalize their roster before the competition commences.
 
-**League Series:** League play (regular season, playoffs, and final matches) is governed by a **Substitution Token** system described below. Teams advancing to a league phase must adhere to the roster lock deadline, defined as **the last scheduled qualifier date for that season, or the date communicated by tournament administration** if no qualifiers exist.
+**League Series:** League play (regular season, playoffs, and final matches) is governed by a **Substitution Token** system described below, unless a game-specific rulebook defines an alternative league roster mechanism. Teams advancing to a league phase must adhere to the roster lock deadline, defined as **the last scheduled qualifier date for that season, or the date communicated by tournament administration** if no qualifiers exist.
+
+Where qualification from a qualifier or prior phase grants entry into a subsequent competition phase, the team must retain a majority of players from its qualifying roster, unless a game-specific or competition-specific rule imposes a stricter requirement, or tournament administration grants an exceptional approval under Section 2.4.2.
 
 #### 2.4.4. Substitution Tokens (League Series Only)
 

--- a/rocketleague.md
+++ b/rocketleague.md
@@ -52,7 +52,7 @@ The Tournament Administration may grant **special exemptions** to:
 
 ### 2.6 Roster Locks
 - Teams must retain the roster submitted during the **qualifier** (if applicable).
-- Up to **two (2) player substitutions** may be made before the **season-specific roster lock deadline**.
+- Up to **two (1) player substitutions** may be made before the **season-specific roster lock deadline**.
 - After this deadline, all roster changes must follow the official procedure.
 
 ---

--- a/rocketleague.md
+++ b/rocketleague.md
@@ -52,7 +52,6 @@ The Tournament Administration may grant **special exemptions** to:
 
 ### 2.6 Roster Locks
 - Teams must retain the roster submitted during the **qualifier** (if applicable).
-- Up to **two (1) player substitutions** may be made before the **season-specific roster lock deadline**.
 - After this deadline, all roster changes must follow the official procedure.
 
 ---

--- a/rocketleague.md
+++ b/rocketleague.md
@@ -74,7 +74,7 @@ All Rocket League matches in the Ibex Gaming League are played in **3v3 Soccar M
 | Setting          | Value                     |
 |------------------|---------------------------|
 | Game Mode        | Soccar (3v3)              |
-| Arena            | DFH Stadium (default)     |
+| Arena            | DFH Stadium (unless specified otherwise)     |
 | Team Size        | 3v3                       |
 | Bot Difficulty   | No Bots                   |
 | Mutators         | None                      |
@@ -104,12 +104,12 @@ All Rocket League matches in the Ibex Gaming League are played in **3v3 Soccar M
 ### 4.1 Player Streaming
 
 - Players may stream their **own point-of-view (POV)** gameplay with a **minimum 2-minute delay**.
-- Streams must include **"Ibex Gaming League"** in the title.
+- Streams must include the name of the competition in the title e.g. "Ibex Gaming Circuit | Premier Division | Winter Season 2026".
 - **Official broadcasts take precedence** over any personal stream. Players must comply with admin instructions regarding media restrictions.
 
 ### 4.2 Voice Channels & Listen-Ins
 
-- All teams must use the **designated Ibex Discord voice channels** during official matches.
+- All teams must use the **designated Discord voice channels** during official matches if requested by the administrators.
 - For streamed matches, **listen-ins** may be used as part of the broadcast unless a team **opts out in advance**.
 - One (1) player per team may be asked to participate in **post-match interviews** during or after official broadcasts.
 

--- a/rocketleague.md
+++ b/rocketleague.md
@@ -103,7 +103,7 @@ All Rocket League matches in the Ibex Gaming League are played in **3v3 Soccar M
 ### 4.1 Player Streaming
 
 - Players may stream their **own point-of-view (POV)** gameplay with a **minimum 2-minute delay**.
-- Streams must include the name of the competition in the title e.g. "Ibex Gaming Circuit | Premier Division | Winter Season 2026".
+- Streams must include the name of the competition in the title e.g. "Ibex Gaming League | Premier Division | Winter Season 2026".
 - **Official broadcasts take precedence** over any personal stream. Players must comply with admin instructions regarding media restrictions.
 
 ### 4.2 Voice Channels & Listen-Ins

--- a/rocketleague.md
+++ b/rocketleague.md
@@ -35,12 +35,12 @@ By participating, all teams and players agree to:
 ### 2.2 Swiss Residency Requirement
 At least **2 of the 3 playing individuals** must:
 - Hold **Swiss citizenship**, or  
-- Reside in Switzerland and possess at least a **B-permit**.
+- Reside in Switzerland and possess at least a **B-permit**, or
+- Either being a citizen or permanent resident of the Principality of Lichtenstein,
 
 ### 2.3 Foreign Player Exceptions
 The Tournament Administration may grant **special exemptions** to:
-- **Residents of the Principality of Liechtenstein**, or  
-- **Players who have participated in at least 3 Swiss Rocket League events within the past 400 days and have been part of the same Swiss esports organisation for more than 3 consecutive months.**
+**Players who have participated in at least 3 Swiss Rocket League events within the past 400 days and have been part of the same Swiss esports organisation for more than 3 consecutive months.**
 
 ### 2.4 Account Registration
 - All players must register their **primary Epic Games ID** (and Steam ID, if applicable).

--- a/rocketleague.md
+++ b/rocketleague.md
@@ -121,9 +121,9 @@ All Rocket League matches in the Ibex Gaming League are played in **3v3 Soccar M
 
 ### 4.1 Player Streaming
 
-- Players may stream their **own point-of-view (POV)** gameplay with a **minimum 2-minute delay**.
-- Streams must include the name of the competition in the title e.g. "Ibex Gaming League | Premier Division | Winter Season 2026".
-- **Official broadcasts take precedence** over any personal stream. Players must comply with admin instructions regarding media restrictions.
+- Players may stream their **own point-of-view (POV)** gameplay.
+- Streams must include the name of the competition in the title e.g. "Ibex Gaming League | <Division> | <Season>".
+- **Official broadcasts take precedence** over any personal stream. Players must comply with admin instructions regarding media restrictions (e.g. added delay of 2 minutes).
 
 ### 4.2 Voice Channels & Listen-Ins
 

--- a/rocketleague.md
+++ b/rocketleague.md
@@ -42,7 +42,7 @@ At least **2 of the 3 playing individuals** must:
 The Tournament Administration may grant **special exemptions** to:
 **Players who have participated in at least 3 Swiss Rocket League events, including at least 1 Swiss offline event, within the past 365 days and are currently representing a Swiss esports organisation.**
 ### 2.4 Account Registration
-- All players must register their **primary Epic Games ID** (and Steam ID, if applicable) or have a username that resembles their in-game name.
+- All players must register their **primary Epic Games ID** (and Steam ID, if applicable) or have a username that clearly identifies them (e.g., contains their gamertag or is recognizable to admins).
 - **Account sharing, smurfing, or multi-teaming** is strictly prohibited.
 
 ### 2.5 Substitutions

--- a/rocketleague.md
+++ b/rocketleague.md
@@ -40,8 +40,7 @@ At least **2 of the 3 playing individuals** must:
 
 ### 2.3 Foreign Player Exceptions
 The Tournament Administration may grant **special exemptions** to:
-**Players who have participated in at least 3 Swiss Rocket League events, including at least 1 Swiss offline event, within the past 365 days and are part of a Swiss esports organisation.**
-
+**Players who have participated in at least 3 Swiss Rocket League events, including at least 1 Swiss offline event, within the past 365 days and are currently represent a Swiss esports organisation.**
 ### 2.4 Account Registration
 - All players must register their **primary Epic Games ID** (and Steam ID, if applicable) or have a username that resembles their in-game name.
 - **Account sharing, smurfing, or multi-teaming** is strictly prohibited.

--- a/rocketleague.md
+++ b/rocketleague.md
@@ -43,7 +43,7 @@ The Tournament Administration may grant **special exemptions** to:
 **Players who have participated in at least 3 Swiss Rocket League events, including at least 1 Swiss offline event, within the past 365 days and are part of a Swiss esports organisation.**
 
 ### 2.4 Account Registration
-- All players must register their **primary Epic Games ID** (and Steam ID, if applicable).
+- All players must register their **primary Epic Games ID** (and Steam ID, if applicable) or have a username that resembles their in-game name.
 - **Account sharing, smurfing, or multi-teaming** is strictly prohibited.
 
 ### 2.5 Substitutions
@@ -51,7 +51,6 @@ The Tournament Administration may grant **special exemptions** to:
 - **Emergency substitutes** require prior **admin approval**.
 
 ### 2.6 Roster Management
-
 Roster management differs between tournaments/qualifiers and league series:
 
 Changes made to a team's roster do not automatically apply to the running competition; changes are only effective once announced to admins and listed on the official competition page.

--- a/rocketleague.md
+++ b/rocketleague.md
@@ -56,7 +56,7 @@ Changes made to a team's roster do not automatically apply to the running compet
 
 **Tournaments and Qualifiers:** Rosters are locked at the start and **no roster changes are permitted** during the tournament or qualifier, except for emergency substitutions. Teams must finalize their roster before the competition starts.
 
-**League Series:** Rocket League does not use the Substitution Token system. Teams may add players during league play up to the maximum roster size defined per competition (e.g., 5 players total, allowing 2 additions beyond the required 3 starters). Teams must maintain the minimum amount of players specified at all times.
+**League Series:** Rocket League does not use the Substitution Token system. Teams may add players during league play up to the maximum roster size defined per competition (e.g., 5 players total, allowing 2 additions beyond the required 3 starters). Teams must maintain the minimum number of players specified at all times.
 
 For league series, each successful player addition consumes one available addition slot up to the maximum roster size. Removing a player does not reopen or create a new addition slot.
 

--- a/rocketleague.md
+++ b/rocketleague.md
@@ -40,7 +40,7 @@ At least **2 of the 3 playing individuals** must:
 
 ### 2.3 Foreign Player Exceptions
 The Tournament Administration may grant **special exemptions** to:
-**Players who have participated in at least 3 Swiss Rocket League events within the past 400 days and have been part of the same Swiss esports organisation for more than 3 consecutive months.**
+**Players who have participated in at least 3 Swiss Rocket League events, including at least 1 Swiss offline event, within the past 365 days and are part of a Swiss esports organisation.**
 
 ### 2.4 Account Registration
 - All players must register their **primary Epic Games ID** (and Steam ID, if applicable).

--- a/rocketleague.md
+++ b/rocketleague.md
@@ -56,13 +56,11 @@ Changes made to a team's roster do not automatically apply to the running compet
 
 **Tournaments and Qualifiers:** Rosters are locked at the start and **no roster changes are permitted** during the tournament or qualifier, except for emergency substitutions. Teams must finalize their roster before the competition starts.
 
-**League Series:** Rocket League does not use the Substitution Token system. Teams may add players during league play up to the maximum roster size of **5 players**. Teams must maintain at least **3 active players** at all times.
+**League Series:** Rocket League does not use the Substitution Token system. Teams may add players during league play up to the maximum roster size defined per competition. Teams must maintain at least **3 active players** at all times.
 
 For league series, each successful player addition consumes one available addition slot up to the maximum roster size. Removing a player does not reopen or create a new addition slot.
 
 For league series, player transfers are only permitted upward to a higher division.
-
-For complete details on roster lock deadlines and shared roster procedures, refer to the General Rulebook Section 2.4.
 
 ---
 

--- a/rocketleague.md
+++ b/rocketleague.md
@@ -56,7 +56,7 @@ Changes made to a team's roster do not automatically apply to the running compet
 
 **Tournaments and Qualifiers:** Rosters are locked at the start and **no roster changes are permitted** during the tournament or qualifier, except for emergency substitutions. Teams must finalize their roster before the competition starts.
 
-**League Series:** Rocket League does not use the Substitution Token system. Teams may add players during league play up to the maximum roster size defined per competition. Teams must maintain at least **3 active players** at all times.
+**League Series:** Rocket League does not use the Substitution Token system. Teams may add players during league play up to the maximum roster size defined per competition (e.g., 5 players total, allowing 2 additions beyond the required 3 starters). Teams must maintain the minimum amount of players specified at all times.
 
 For league series, each successful player addition consumes one available addition slot up to the maximum roster size. Removing a player does not reopen or create a new addition slot.
 

--- a/rocketleague.md
+++ b/rocketleague.md
@@ -36,13 +36,13 @@ By participating, all teams and players agree to:
 At least **2 of the 3 playing individuals** must:
 - Hold **Swiss citizenship**, or  
 - Reside in Switzerland and possess at least a **B-permit**, or
-- Either being a citizen or permanent resident of the Principality of Lichtenstein,
+- Be a citizen or permanent resident of the Principality of Liechtenstein.
 
 ### 2.3 Foreign Player Exceptions
 The Tournament Administration may grant **special exemptions** to:
-**Players who have participated in at least 3 Swiss Rocket League events, including at least 1 Swiss offline event, within the past 365 days and are currently representing a Swiss esports organisation.**
+- **Players who have participated in at least 3 Swiss Rocket League events, including at least 1 Swiss offline event, within the past 365 days and are currently representing a Swiss esports organisation.**
 ### 2.4 Account Registration
-- All players must register their **primary Epic Games ID** (and Steam ID, if applicable) or have a username that clearly identifies them (e.g., contains their gamertag or is recognizable to admins).
+- - All players must register their **primary game account**.
 - **Account sharing, smurfing, or multi-teaming** is strictly prohibited.
 
 ### 2.5 Substitutions
@@ -70,7 +70,7 @@ For league series, player transfers are only permitted upward to a higher divisi
 
 All Rocket League matches in the Ibex Gaming League are played in **3v3 Soccar Mode** using the **Esports Standard Settings**.
 
-### 3.2 Default Arena
+### 3.2 Default Map Rotation
 
 - The default map rotation is:
     1. Mannfield (Night)
@@ -103,7 +103,7 @@ All Rocket League matches in the Ibex Gaming League are played in **3v3 Soccar M
 ### 3.4 Lobby Setup & Hosting
 
 - In **regular season**, teams create their own lobbies as instructed by admins.
-- The first team listed on the match page is responsible to host the lobby and plays on the blue side.  
+- The first team listed on the match page is responsible for hosting the lobby and plays on the blue side.  
 - For **playoffs and broadcasted matches**, the **Tournament Administration** may host the lobby.  
 - Lobby credentials will be provided before the match – all lobbies have to be created with the credentials provided.
 

--- a/rocketleague.md
+++ b/rocketleague.md
@@ -50,9 +50,17 @@ The Tournament Administration may grant **special exemptions** to:
 - Teams may use their registered substitute **before a match**.
 - **Emergency substitutes** require prior **admin approval**.
 
-### 2.6 Roster Locks
-- Teams must retain the roster submitted during the **qualifier** (if applicable).
-- After this deadline, all roster changes must follow the official procedure.
+### 2.6 Roster Management
+
+Roster management differs between tournaments/qualifiers and league series:
+
+Changes made to a team's roster do not automatically apply to the running competition; changes are only effective once announced to admins and listed on the official competition page.
+
+**Tournaments and Qualifiers:** Rosters are locked at the start and **no roster changes are permitted** during the tournament or qualifier, except for emergency substitutions. Teams must finalize their roster before the competition starts.
+
+**League Series:** Rosters are managed through the **Substitution Token** system defined in the General Rulebook (Section 2.4.4). Maximum roster size for Rocket League league series is **5 players**. Teams must maintain at least **3 active players** at all times.
+
+For complete details on token allocation, usage, and roster lock deadlines, refer to the General Rulebook Section 2.4.
 
 ---
 

--- a/rocketleague.md
+++ b/rocketleague.md
@@ -72,16 +72,26 @@ All Rocket League matches in the Ibex Gaming League are played in **3v3 Soccar M
 
 ### 3.2 Default Arena
 
-- The default arena is **DFH Stadium (Standard)**.  
+- The default map rotation is:
+    1. Mannfield (Night)
+    2. Forbidden Temple
+    3. DFH Stadium
+    4. Utopia Coliseum (Dusk)
+    5. Sovereign Heights
+    6. Neo Tokyo
+    7. Champions Field
+
+- Maps are selected sequentially from the rotation (game 1 uses map 1, game 2 uses map 2, etc.).
+- If a series extends beyond 7 games, the rotation restarts from map 1.
 - If both teams agree, or if required for performance reasons, other standard arenas may be used.  
-- The Tournament Administration may enforce specific arenas if needed.
+- The Tournament Administration may enforce other specific arenas if needed.
 
 ### 3.3 Game Settings
 
 | Setting          | Value                     |
 |------------------|---------------------------|
 | Game Mode        | Soccar (3v3)              |
-| Arena            | DFH Stadium (unless specified otherwise)     |
+| Arena            | Per defined map rotation  |
 | Team Size        | 3v3                       |
 | Bot Difficulty   | No Bots                   |
 | Mutators         | None                      |
@@ -92,9 +102,10 @@ All Rocket League matches in the Ibex Gaming League are played in **3v3 Soccar M
 
 ### 3.4 Lobby Setup & Hosting
 
-- In **regular season**, teams may create their own lobbies if instructed by admins.  
-- For **playoffs and broadcasted matches**, the **Tournament Administration** will host the lobby.  
-- Lobby credentials will be provided shortly before the match.
+- In **regular season**, teams create their own lobbies as instructed by admins.
+- The first team listed on the match page is responsible to host the lobby and plays on the blue side.  
+- For **playoffs and broadcasted matches**, the **Tournament Administration** may host the lobby.  
+- Lobby credentials will be provided before the match – all lobbies have to be created with the credentials provided.
 
 ### 3.5 Timeouts (Best-of-7 Only)
 

--- a/rocketleague.md
+++ b/rocketleague.md
@@ -40,7 +40,7 @@ At least **2 of the 3 playing individuals** must:
 
 ### 2.3 Foreign Player Exceptions
 The Tournament Administration may grant **special exemptions** to:
-**Players who have participated in at least 3 Swiss Rocket League events, including at least 1 Swiss offline event, within the past 365 days and are currently represent a Swiss esports organisation.**
+**Players who have participated in at least 3 Swiss Rocket League events, including at least 1 Swiss offline event, within the past 365 days and are currently representing a Swiss esports organisation.**
 ### 2.4 Account Registration
 - All players must register their **primary Epic Games ID** (and Steam ID, if applicable) or have a username that resembles their in-game name.
 - **Account sharing, smurfing, or multi-teaming** is strictly prohibited.

--- a/rocketleague.md
+++ b/rocketleague.md
@@ -58,9 +58,13 @@ Changes made to a team's roster do not automatically apply to the running compet
 
 **Tournaments and Qualifiers:** Rosters are locked at the start and **no roster changes are permitted** during the tournament or qualifier, except for emergency substitutions. Teams must finalize their roster before the competition starts.
 
-**League Series:** Rosters are managed through the **Substitution Token** system defined in the General Rulebook (Section 2.4.4). Maximum roster size for Rocket League league series is **5 players**. Teams must maintain at least **3 active players** at all times.
+**League Series:** Rocket League does not use the Substitution Token system. Teams may add players during league play up to the maximum roster size of **5 players**. Teams must maintain at least **3 active players** at all times.
 
-For complete details on token allocation, usage, and roster lock deadlines, refer to the General Rulebook Section 2.4.
+For league series, each successful player addition consumes one available addition slot up to the maximum roster size. Removing a player does not reopen or create a new addition slot.
+
+For league series, player transfers are only permitted upward to a higher division.
+
+For complete details on roster lock deadlines and shared roster procedures, refer to the General Rulebook Section 2.4.
 
 ---
 


### PR DESCRIPTION
This PR aligns General, CS2, and Rocket League rules for clearer roster governance and match operations and reflects the SS26 changes discussed with the established Premier Division teams.

## Key changes:
**1. General:**
- Formalised roster lock/change process and qualifier-to-league majority retention.
- Added strict criteria, disclosure, and appealability for permanent exceptional roster approvals.
- Updated regular-season reschedule notice to 24h and clarified streamed-match rescheduling limits.

**2. Counter-Strike 2:**
- Reworked substitutions into phase-based roster management.
- Added league-specific transfer eligibility, foreign-player post-regular-season restriction, and token refill behaviour.
- Clarified regular-season rescheduling announcement requirements.

**3. Rocket League:**
- Updated Swiss/foreign eligibility and account-identification wording.
- Replaced old roster-lock wording with phase-based roster management and finite league player additions (no token system).
- Added upward-only league transfers.
- Clarified map rotation, lobby-hosting flow, and stream/voice-channel requirements.